### PR TITLE
Fix simulation consistency and memory leaks

### DIFF
--- a/src/bounds.hpp
+++ b/src/bounds.hpp
@@ -31,6 +31,7 @@
 /// Represent the bounds of a Plate.
 class IBounds {
 public:
+    virtual ~IBounds() {}
 
     /// Accept plate relative coordinates and return the index inside the plate.
     /// The index can be used with other classes to retrieve information about specific points.

--- a/src/mass.hpp
+++ b/src/mass.hpp
@@ -48,6 +48,7 @@ private:
 class IMass
 {
 public:
+    virtual ~IMass() {}
     virtual float getMass() const = 0;
     virtual FloatPoint massCenter() const = 0;
 };

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -26,6 +26,12 @@
 #define M_PI 3.141592654
 #endif
 
+#if (defined(_MSC_VER) && defined(_M_X64)) || \
+    (defined(__APPLE__) && defined(__clang__))
+#define sin(x) static_cast<float>(sin(static_cast<double>(x)))
+#define cos(x) static_cast<float>(cos(static_cast<double>(x)))
+#endif
+
 Movement::Movement(SimpleRandom randsource, const WorldDimension& worldDimension)
     : _randsource(randsource),
       velocity(1),

--- a/src/movement.hpp
+++ b/src/movement.hpp
@@ -43,6 +43,7 @@ class Mass;
 class IMovement
 {
 public:
+    virtual ~IMovement() {}
     virtual Platec::FloatVector velocityUnitVector() const = 0;
     virtual void decImpulse(const Platec::FloatVector& delta) = 0;
 };

--- a/src/noise.cpp
+++ b/src/noise.cpp
@@ -24,6 +24,11 @@
 #include "simplexnoise.hpp"
 #include "utils.hpp"
 
+#if defined(_MSC_VER) && defined(_M_X64)
+#define sinf(x) ((float)sin((double)x))
+#define cosf(x) ((float)cos((double)x))
+#endif
+
 static const float SQRDMD_ROUGHNESS = 0.35f;
 static const float SIMPLEX_PERSISTENCE = 0.25f;
 #define PI 3.14159265
@@ -41,7 +46,7 @@ static uint32_t nearest_pow(uint32_t num)
 
 void createSlowNoise(float* map, const WorldDimension& tmpDim, SimpleRandom randsource)
 {
-    long seed = randsource.next();
+    int64_t seed = randsource.next();
     uint32_t width = tmpDim.getWidth();
     uint32_t height = tmpDim.getHeight();
     float persistence = 0.25f;

--- a/src/noise.cpp
+++ b/src/noise.cpp
@@ -24,7 +24,8 @@
 #include "simplexnoise.hpp"
 #include "utils.hpp"
 
-#if defined(_MSC_VER) && defined(_M_X64)
+#if (defined(_MSC_VER) && defined(_M_X64)) || \
+    (defined(__APPLE__) && defined(__clang__))
 #define sinf(x) static_cast<float>(sin(static_cast<double>(x)))
 #define cosf(x) static_cast<float>(cos(static_cast<double>(x)))
 #endif

--- a/src/noise.cpp
+++ b/src/noise.cpp
@@ -25,8 +25,8 @@
 #include "utils.hpp"
 
 #if defined(_MSC_VER) && defined(_M_X64)
-#define sinf(x) ((float)sin((double)x))
-#define cosf(x) ((float)cos((double)x))
+#define sinf(x) static_cast<float>(sin(static_cast<double>(x)))
+#define cosf(x) static_cast<float>(cos(static_cast<double>(x)))
 #endif
 
 static const float SQRDMD_ROUGHNESS = 0.35f;

--- a/src/plate.hpp
+++ b/src/plate.hpp
@@ -35,6 +35,7 @@
 class IPlate : public IMass, public IMovement
 {
 public:
+    virtual ~IPlate() {}
 };
 
 class plate : public IPlate

--- a/src/segment_creator.cpp
+++ b/src/segment_creator.cpp
@@ -108,17 +108,17 @@ ContinentId MySegmentCreator::createSegment(uint32_t x, uint32_t y) const throw(
     uint32_t lines_processed;
     Platec::Rectangle rect(_worldDimension, x, x, y, y);
     SegmentData* pData = new SegmentData(rect, 0);
-    static vector<uint32_t>* spans_todo = NULL;
-    static vector<uint32_t>* spans_done = NULL;
+    static vector<vector<uint32_t> > spans_todo;
+    static vector<vector<uint32_t> > spans_done;
     static uint32_t spans_size = 0;
     // MK: This code was originally allocating the 2D arrays per function call.
     // This was eating up a tremendous amount of cpu.
     // They are now static and they grow as needed, which turns out to be seldom.
     if (spans_size < bounds_height) {
-        delete[] spans_todo;
-        delete[] spans_done;
-        spans_todo = new vector<uint32_t>[bounds_height];
-        spans_done = new vector<uint32_t>[bounds_height];
+        spans_todo.clear();
+        spans_done.clear();
+        spans_todo.resize(bounds_height);
+        spans_done.resize(bounds_height);
         spans_size = bounds_height;
     }
     _segments->setId(origin_index, ID);
@@ -135,7 +135,7 @@ ContinentId MySegmentCreator::createSegment(uint32_t x, uint32_t y) const throw(
             if (spans_todo[line].empty())
                 continue;
 
-            scanSpans(line, start, end, spans_todo, spans_done);
+            scanSpans(line, start, end, spans_todo.data(), spans_done.data());
 
             if (start > end) // Nothing to do here anymore...
                 continue;

--- a/src/segment_data.hpp
+++ b/src/segment_data.hpp
@@ -26,6 +26,7 @@
 class ISegmentDataAccess
 {
 public:
+    virtual ~ISegmentDataAccess() {}
     virtual uint32_t getLeft() const = 0;
     virtual uint32_t getRight() const = 0;
     virtual uint32_t getTop() const = 0;
@@ -38,6 +39,7 @@ public:
 class ISegmentData : public ISegmentDataAccess
 {
 public:
+    virtual ~ISegmentData() {}
     virtual void incCollCount() = 0;
     virtual void incArea() = 0;
     virtual void enlarge_to_contain(uint32_t x, uint32_t y) = 0;

--- a/src/segments.cpp
+++ b/src/segments.cpp
@@ -44,6 +44,9 @@ uint32_t Segments::area()
 void Segments::reset()
 {
     memset(segment, -1, sizeof(uint32_t) * _area);
+    for (int i = 0; i<seg_data.size(); i++) {
+        delete seg_data[i];
+    }
     seg_data.clear();
 }
 

--- a/src/segments.cpp
+++ b/src/segments.cpp
@@ -31,7 +31,7 @@ Segments::~Segments()
     delete[] segment;
     segment = NULL;
     _area = 0;
-    for (int i=0; i<seg_data.size(); i++) {
+    for (int i = 0; i < seg_data.size(); i++) {
         delete seg_data[i];
     }
 }
@@ -44,7 +44,7 @@ uint32_t Segments::area()
 void Segments::reset()
 {
     memset(segment, -1, sizeof(uint32_t) * _area);
-    for (int i = 0; i<seg_data.size(); i++) {
+    for (int i = 0; i < seg_data.size(); i++) {
         delete seg_data[i];
     }
     seg_data.clear();

--- a/src/segments.hpp
+++ b/src/segments.hpp
@@ -37,6 +37,7 @@ typedef uint32_t ContinentId;
 class ISegments
 {
 public:
+    virtual ~ISegments() {}
     virtual uint32_t area() = 0;
     virtual void reset() = 0;
     virtual void reassign(uint32_t newarea, uint32_t* tmps) = 0;


### PR DESCRIPTION
I was getting wildly different simulation results with Visual C++, using the same seed/parameters that I was using on Linux or OS X. Most of that was caused by the fact that `sizeof(long)` is 4, as opposed to 8 on Clang, GCC, etc.

`float kc = (seed*seed) % 256;`

On this line in particular, the signed 32-bit integer would often overflow into the negatives. Making it explicitly 64-bit keeps behavior consistent across platforms.

That mostly fixes it, but I was still seeing subtle inconsistencies. This is harder to explain. For some reason, `sinf` yields different results when MSVC (2013 or 2015) produces a 64-bit binary. For example, with floats expressed as their raw bytes:

`sinf(5.516943f)` = `0xbf3184cd` on GCC, Clang, and MSVC x86
`sinf(5.516943f)` = `0xbf3184ce` on MSVC x86-64

Tried adjusting some flags, but it didn't help. Using the double version of `sin` and then casting back to float gets the correct results. This solution is a little ugly, but it's the only thing that worked.
