### PR TITLE
Stop it from repeating itself in the Y

### DIFF
--- a/src/simplexnoise.cpp
+++ b/src/simplexnoise.cpp
@@ -550,7 +550,7 @@ int simplexnoise(int32_t seed, float* map, int width, int height, float persiste
             float fNX = x * inv_width; // we let the x-offset define the circle
             float fNY = y * inv_height; // we let the x-offset define the circle
             float fRdx = (float)(fNX * 2 * PI); // a full circle is two pi radians
-            float fRdy = (float)(fNY * 4 * PI); // a full circle is two pi radians
+            float fRdy = (float)(fNY * 2 * PI); // a full circle is two pi radians
             float a = sinf(fRdx);
             float b = cosf(fRdx);
             float c = sinf(fRdy);


### PR DESCRIPTION
I was translating this to C# and noticed that it was repeating itself in the Y.

I don't know if that was on purpose for this repository. If it was ignore this PR.

Example

Before
![image](https://user-images.githubusercontent.com/2976266/105952720-95f10300-6037-11eb-8197-ab1ac5fac7da.png)

After
![image](https://user-images.githubusercontent.com/2976266/105952660-7eb21580-6037-11eb-8a0b-e68167d66c14.png)
