### PR TITLE
Removed throw(invalid_argument) (caused compile error during installation with pip3 and gcc)

### DIFF
--- a/src/lithosphere.cpp
+++ b/src/lithosphere.cpp
@@ -70,7 +70,7 @@ void lithosphere::createSlowNoise(float* tmp, const WorldDimension& tmpDim)
 
 lithosphere::lithosphere(long seed, uint32_t width, uint32_t height, float sea_level,
                          uint32_t _erosion_period, float _folding_ratio, uint32_t aggr_ratio_abs,
-                         float aggr_ratio_rel, uint32_t num_cycles, uint32_t _max_plates) throw(invalid_argument) :
+                         float aggr_ratio_rel, uint32_t num_cycles, uint32_t _max_plates): // throw(invalid_argument) :
     hmap(width, height),
     amap(width, height),
     imap(width, height),

--- a/src/lithosphere.hpp
+++ b/src/lithosphere.hpp
@@ -87,7 +87,7 @@ public:
                 float sea_level,
                 uint32_t _erosion_period, float _folding_ratio,
                 uint32_t aggr_ratio_abs, float aggr_ratio_rel,
-                uint32_t num_cycles, uint32_t _max_plates) throw(std::invalid_argument);
+                uint32_t num_cycles, uint32_t _max_plates); // throw(std::invalid_argument);
 
     ~lithosphere() throw(); ///< Standard destructor.
 


### PR DESCRIPTION
I was unable to install the python library, both from pip's repository and when cloned locally.
The compiler was complaining that `throw(<something>)` is obsolete.

Just removed `throw(invalid_argument)` from the constructor of `litosphere` and was now able to install the python package.
The tests also passed on my system. 